### PR TITLE
Switch to slim rust image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM rust:latest
+FROM rust:slim
+
+# install curl, slim image doesn't have it
+RUN apt update 
+RUN apt-get install curl -y
 
 RUN curl --silent -L --output cargo-deny.tar.gz https://github.com/EmbarkStudios/cargo-deny/releases/download/0.4.2/cargo-deny-0.4.2-x86_64-unknown-linux-musl.tar.gz
 RUN tar -xzvf cargo-deny.tar.gz -C . --strip-components=1


### PR DESCRIPTION
Reduces image size from 1.6 GB to 1.0 GB. Not great but better.

Part of #3
