### PR TITLE
Switch to alpine docker base image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,5 +10,8 @@ jobs:
       - name: Build Docker image
         run: docker build -t test-cargo-deny .
 
-      - name: Run Docker image
+      - name: Run list
+        run: docker run -v ${PWD}/test:/test --workdir /test test-cargo-deny list
+
+      - name: Run check
         run: docker run -v ${PWD}/test:/test --workdir /test test-cargo-deny check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM rust:slim
+FROM rust:alpine
 
-# install curl, slim image doesn't have it
-RUN apt update 
-RUN apt-get install curl -y
+RUN apk add --no-cache curl
 
 RUN curl --silent -L --output cargo-deny.tar.gz https://github.com/EmbarkStudios/cargo-deny/releases/download/0.4.2/cargo-deny-0.4.2-x86_64-unknown-linux-musl.tar.gz
 RUN tar -xzvf cargo-deny.tar.gz -C . --strip-components=1


### PR DESCRIPTION
Use alpine instead of debian-slim as Rust base docker image, this reduces the overall image size from 1.0 GB to to 700 MB and reduces image build time from 45 seconds to 25 seconds.

Part of #3. 