### PR TITLE
Upgrade cargo-deny 0.6.6 -> 0.6.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:alpine
 
 RUN apk add --no-cache curl
 
-RUN curl --silent -L --output cargo-deny.tar.gz https://github.com/EmbarkStudios/cargo-deny/releases/download/0.6.6/cargo-deny-0.6.6-x86_64-unknown-linux-musl.tar.gz
+RUN curl --silent -L --output cargo-deny.tar.gz https://github.com/EmbarkStudios/cargo-deny/releases/download/0.6.7/cargo-deny-0.6.7-x86_64-unknown-linux-musl.tar.gz
 RUN tar -xzvf cargo-deny.tar.gz -C . --strip-components=1
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
0.6.7 looks fully compatible so will do a new patch release of the action as well with this