### PR TITLE
Add support for always using latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         run: docker build -t test-cargo-deny .
 
       - name: Run list
-        run: docker run -v ${PWD}/test:/test test-cargo-deny --context test list
+        run: docker run -v ${PWD}/test:/test test-cargo-deny --manifest-path /test/Cargo.toml list
 
       - name: Run check
-        run: docker run -v ${PWD}/test:/test test-cargo-deny --context test check
+        run: docker run -v ${PWD}/test:/test test-cargo-deny --manifest-path /test/Cargo.toml check

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM rust:alpine
 
 RUN apk add --no-cache curl
 
-RUN curl --silent -L --output cargo-deny.tar.gz https://github.com/EmbarkStudios/cargo-deny/releases/download/0.6.8/cargo-deny-0.6.8-x86_64-unknown-linux-musl.tar.gz
-RUN tar -xzvf cargo-deny.tar.gz -C . --strip-components=1
+ENV version 0.7.3
+
+RUN curl -L https://github.com/EmbarkStudios/cargo-deny/releases/download/${version}/cargo-deny-${version}-x86_64-unknown-linux-musl.tar.gz | tar xzv -C . --strip-components=1
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:alpine
 
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl grep
 
 ENV version 0.7.3
 

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,16 @@ inputs:
     description: "The log level for cargo-deny"
     required: false
     default: "warn"
+  use-latest:
+    description: "Always runs the latest release of cargo-deny"
+    required: false
+    default: "false"
 
 runs:
   using: "docker"
   image: "Dockerfile"
+  env:
+    USE_LATEST: ${{ inputs.use-latest }}
   args:
     - --log-level
     - ${{ inputs.log-level }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,14 @@
 
 PATH=$PATH:/usr/local/cargo/bin
 
+if [ "$USE_LATEST" = "true" ]; then
+    latest=$(curl --silent --fail https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/latest | grep -oP '(?<=\"tag_name\": \").+?(?=\")')
+    current=$(/cargo-deny -V | cut -d' ' -f 2)
+
+    if [ ! "$latest" = "$current" ]; then
+        echo "::warning ::cargo-deny version $current is out of date, updating to $latest"
+        curl -L https://github.com/EmbarkStudios/cargo-deny/releases/download/"${latest}"/cargo-deny-"${latest}"-x86_64-unknown-linux-musl.tar.gz | tar xzv -C . --strip-components=1
+    fi
+fi
+
 /cargo-deny $*

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@
 
 PATH=$PATH:/usr/local/cargo/bin
 
-/./cargo-deny $*
+/cargo-deny $*

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,4 +12,5 @@ if [ "$USE_LATEST" = "true" ]; then
     fi
 fi
 
+/cargo-deny -V
 /cargo-deny $*


### PR DESCRIPTION
Add the `use-latest` argument to the action, which when set to true, will check the latest release for cargo-deny and download it if the current version in the container is not the same.

Might be considered to close #19 