### PR TITLE
Upgrade cargo-deny 0.6.8 -> 0.7.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         run: docker build -t test-cargo-deny .
 
       - name: Run list
-        run: docker run -v ${PWD}/test:/test test-cargo-deny --context test list
+        run: docker run -v ${PWD}/test:/test test-cargo-deny --manifest-path test/Cargo.toml list
 
       - name: Run check
-        run: docker run -v ${PWD}/test:/test test-cargo-deny --context test check
+        run: docker run -v ${PWD}/test:/test test-cargo-deny --manifest-path test/Cargo.toml check

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:alpine
 
 RUN apk add --no-cache curl
 
-RUN curl --silent -L --output cargo-deny.tar.gz https://github.com/EmbarkStudios/cargo-deny/releases/download/0.6.8/cargo-deny-0.6.8-x86_64-unknown-linux-musl.tar.gz
+RUN curl --silent -L --output cargo-deny.tar.gz https://github.com/EmbarkStudios/cargo-deny/releases/download/0.7.3/cargo-deny-0.7.3-x86_64-unknown-linux-musl.tar.gz
 RUN tar -xzvf cargo-deny.tar.gz -C . --strip-components=1
 
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The action has three optional inputs
 
 * `log-level`: The log level to use for `cargo-deny`, default is `warn`
 * `command`: The command to use for `cargo-deny`, default is `check`
-* `arguments`: The argument to pass to `cargo-deny`, default is `--all-features`
+* `arguments`: The argument to pass to `cargo-deny`, default is `--all-features`. See [Common Options](https://embarkstudios.github.io/cargo-deny/cli/common.html) for a list of the available options.
 
 ### Example pipeline
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ GitHub Action for running [`cargo-deny`](https://github.com/EmbarkStudios/cargo-
 Create a `deny.toml` file in the root of the repo to use as rules for the action ([example](https://github.com/EmbarkStudios/cargo-deny/blob/master/deny.toml)).
 See [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny) for instructions and details of the format and capabilities.
 
-This action will run `cargo-deny check` and report failure if any banned crates or disallowed open souce licenses are found used in the crate or its dependencies.
+This action will run `cargo-deny check` and report failure if any banned crates or disallowed open source licenses are found used in the crate or its dependencies.
+
+The action has three optional inputs
+
+* `log-level`: The log level to use for `cargo-deny`, default is `warn`
+* `command`: The command to use for `cargo-deny`, default is `check`
+* `arguments`: The argument to pass to `cargo-deny`, default is `--all-features`
 
 ### Example pipeline
 
@@ -24,6 +30,23 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: EmbarkStudios/cargo-deny-action@v1
+```
+
+### Example pipeline with custom options using default values
+
+```yaml
+name: CI
+on: [push, pull_request]
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        log-level: warn
+        command: check
+        arguments: --all-features
 ```
 
 ## Users

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: "The command to run with cargo-deny"
     required: false
     default: "check"
+  arguments:
+    description: "The arguments to pass to cargo-deny"
+    required: false
+    default: "--all-features"
   log-level:
     description: "The log level for cargo-deny"
     required: false
@@ -22,4 +26,5 @@ runs:
   args:
     - --log-level
     - ${{ inputs.log-level }}
+    - ${{ inputs.arguments }}
     - ${{ inputs.command }}


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Upgrade to latest release of cargo-deny.

Bump the Cargo deny version to 0.7.3.

Update the tests to use --manifest path instead of the now removed
--context option.

### Related Issues

Issues #19 and #20 discuss automated upgrades, but currently the process is manual.
