### PR TITLE
Add a recommended pipeline example to prevent breakages from advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
   cargo-deny:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: EmbarkStudios/cargo-deny-action@v1
 ```
 
@@ -41,12 +41,36 @@ jobs:
   cargo-deny:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: EmbarkStudios/cargo-deny-action@v1
       with:
         log-level: warn
         command: check
         arguments: --all-features
+```
+
+### Recommended pipeline to avoid sudden breakages
+
+```yaml
+name: CI
+on: [push, pull_request]
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check ${{ matrix.checks }}
 ```
 
 ## Users


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

I've found that the simple `check all` breaks the CI and blocks unrelated PRs once RustSec announces an advisory that touches the project where cargo deny job is used. I think ci should be deterministic and not break without changes to code, so I propose to make checking for advisories recommended to be set to optional, but all other checks (bans, sources, licenses) to be required.
