### PR TITLE
Update image to latest cargo-deny

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,4 @@ jobs:
         run: docker run -v ${PWD}/test:/test test-cargo-deny --manifest-path test/Cargo.toml list
 
       - name: Run check
-        run: docker run -v ${PWD}/test:/test test-cargo-deny --manifest-path test/Cargo.toml check
+        run: docker run -v ${PWD}/test:/test test-cargo-deny --manifest-path test/Cargo.toml --all-features check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:slim-buster as build
+FROM rust:1.47-slim-buster as build
 
 ENV deny_version=0.8.0
 
@@ -12,15 +12,12 @@ RUN set -eux; \
     git clone https://github.com/EmbarkStudios/cargo-deny code; \
     cd code; \
     git checkout $deny_version; \
-    cargo build --release --target x86_64-unknown-linux-musl --features standalone; \
+    cargo build --release --target x86_64-unknown-linux-musl; \
     strip target/x86_64-unknown-linux-musl/release/cargo-deny; \
     cp target/x86_64-unknown-linux-musl/release/cargo-deny /cargo-deny;
 
-FROM alpine:3.12.0 as run
+FROM rust:1.47-alpine3.12 as run
 
-COPY --from=build /cargo-deny /
-COPY entrypoint.sh /entrypoint.sh
+COPY --from=build /cargo-deny /usr/bin
 
-RUN apk update && apk add bash
-
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["cargo-deny"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN set -eux; \
     git clone https://github.com/EmbarkStudios/cargo-deny code; \
     cd code; \
     git checkout $deny_version; \
-    cargo build --release --target x86_64-unknown-linux-musl; \
+    cargo build --release --target x86_64-unknown-linux-musl --features standalone; \
     strip target/x86_64-unknown-linux-musl/release/cargo-deny; \
     cp target/x86_64-unknown-linux-musl/release/cargo-deny /cargo-deny;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.47-alpine3.12
 
-ENV deny_version=0.8.0
+ENV deny_version=0.8.1
 
 RUN set -eux; \
     apk update; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,10 @@
-FROM rust:1.47-slim-buster as build
+FROM rust:1.47-alpine3.12
 
 ENV deny_version=0.8.0
 
 RUN set -eux; \
-    apt-get update; \
-    apt-get install -y \
-        git \
-        musl-tools \
-        make; \
-    rustup target add x86_64-unknown-linux-musl; \
-    git clone https://github.com/EmbarkStudios/cargo-deny code; \
-    cd code; \
-    git checkout $deny_version; \
-    cargo build --release --target x86_64-unknown-linux-musl; \
-    strip target/x86_64-unknown-linux-musl/release/cargo-deny; \
-    cp target/x86_64-unknown-linux-musl/release/cargo-deny /cargo-deny;
-
-FROM rust:1.47-alpine3.12 as run
-
-COPY --from=build /cargo-deny /usr/bin
+    apk update; \
+    apk add curl; \
+    curl --silent -L https://github.com/EmbarkStudios/cargo-deny/releases/download/$deny_version/cargo-deny-$deny_version-x86_64-unknown-linux-musl.tar.gz | tar -xzv -C /usr/bin --strip-components=1;
 
 ENTRYPOINT ["cargo-deny"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/sh -l
-
-PATH=$PATH:/usr/local/cargo/bin
-
-/./cargo-deny $*


### PR DESCRIPTION
This changes the image to just use alpine, and removes the need for the entrypoint script.

Updates to latest cargo-deny 0.8.1.