### PR TITLE
Publish Docker image on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Publish Docker image
+
+on: push
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Push to Github Container Registry
+        uses: docker/build-push-action@v2
+        with:
+            push: true
+            tags: ghcr.io/embarkstudios/cargo-deny-action:latest

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "Dockerfile"
+  image: "ghcr.io/embarkstudios/cargo-deny-action:latest"
   args:
     - --log-level
     - ${{ inputs.log-level }}


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This adds an Action to publish a Docker image on a release. It will need a few things to be done:

- [A Github PAT token](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry) (probably from a bot account with maintainer privs on this repo)
- A secret added to this repo with the key `CR_PAT` and the Github PAT from above

I'm not able to test this on my fork, since it would use the org's registry. There might be some debugging that needs to be done, but I think everything should be in place.

### Related Issues

Should help improve #4 and #3
Should close [cargo-deny#299](https://github.com/EmbarkStudios/cargo-deny/issues/299)
