### PR TITLE
Always use latest `rustup` when building the container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@ ENV deny_version=0.8.4
 
 RUN set -eux; \
     apk update; \
-    apk add curl; \
+    apk add bash curl; \
     curl --silent -L https://github.com/EmbarkStudios/cargo-deny/releases/download/$deny_version/cargo-deny-$deny_version-x86_64-unknown-linux-musl.tar.gz | tar -xzv -C /usr/bin --strip-components=1;
+
+# Ensure rustup is up to date.
+RUN bash -c "sh <(curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs) -y"
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This PR runs the official `sh.rustup.rs` installer, to always get the latest `rustup`, even when the base image has an outdated one.

The `1.23.0` release added support for [TOML format `rust-toolchain`](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file), which projects are starting to take advantage of.
On older `rustup` versions, the new TOML `rust-toolchain` will always cause errors and has to be changed/removed.

More specifically, we hit this when trying to use the TOML `rust-toolchain` in https://github.com/EmbarkStudios/rust-gpu/pull/284/#issuecomment-741812600.
