### PR TITLE
Update to 0.9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM rust:1.50-alpine3.12
+FROM rust:1.51-alpine3.12
 
-ENV deny_version="0.9.0"
+ENV deny_version="0.9.1"
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
I haven't read the contributor guidelines in details, but this PR seems insubstantial enough that I hope that it isn't super necessary :pray: 

This PR follows the same model as https://github.com/EmbarkStudios/cargo-deny-action/pull/33 and updates to 0.9.1.
There's also an `alpine3.13` now, I haven't updated to it but can do the little tweak if wanted.
