### PR TITLE
Update to cargo-deny 0.10.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM rust:1.51-alpine3.12
+FROM rust:1.57-alpine
 
-ENV deny_version="0.9.1"
+ENV deny_version="0.10.3"
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Another update, similar to https://github.com/EmbarkStudios/cargo-deny-action/pull/37

This is important in order for `cargo deny` to be able to parse Cargo.toml files that use [custom profiles](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#cargo-support-for-custom-profiles).

Note that I haven't tested this PR. I assume that the changes are trivial enough that it doesn't need testing.
