### PR TITLE
Bump cargo-deny version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.58.1-alpine3.15
 
-ENV deny_version="0.11.1"
+ENV deny_version="0.11.2"
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This PR makes the Docker container use [cargo-deny 0.11.2](https://github.com/EmbarkStudios/cargo-deny/releases). I want the version bumped so that [Radicle Link](https://github.com/radicle-dev/radicle-link) can use the latest version of cargo-deny in [its CI action](https://github.com/radicle-dev/radicle-link/blob/dd5eb3d593c8f8c327db3e4f554007d20e6c3a6f/.github/workflows/ci.yaml#L42).
