### PR TITLE
add git credentials as input parameter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         run: docker build -t test-cargo-deny .
 
       - name: Run list
-        run: docker run -v ${PWD}/test:/test test-cargo-deny "" --manifest-path test/Cargo.toml list
+        run: docker run -v ${PWD}/test:/test test-cargo-deny "" "" --manifest-path test/Cargo.toml list
 
       - name: Run check
-        run: docker run -v ${PWD}/test:/test test-cargo-deny 1.60.0 --manifest-path test/Cargo.toml --all-features check
+        run: docker run -v ${PWD}/test:/test test-cargo-deny 1.60.0 "" --manifest-path test/Cargo.toml --all-features check

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ The action has three optional inputs
 * `log-level`: The log level to use for `cargo-deny`, default is `warn`
 * `command`: The command to use for `cargo-deny`, default is `check`
 * `arguments`: The argument to pass to `cargo-deny`, default is `--all-features`. See [Common Options](https://embarkstudios.github.io/cargo-deny/cli/common.html) for a list of the available options.
-* `command-arguments` The argument to pass to the command, default is emtpy. See options for [each command](https://embarkstudios.github.io/cargo-deny/cli/index.html). 
+* `command-arguments` The argument to pass to the command, default is emtpy. See options for [each command](https://embarkstudios.github.io/cargo-deny/cli/index.html).
+* `credentials` This argument stores the credentials in the file `$HOME/git-credentials`, and configures git to use it. The credential must match the format `https://user:pass@github.com`
 
 ### Example pipeline
 
@@ -54,6 +55,7 @@ jobs:
         command: check
         arguments: --all-features
         command-arguments: ""
+        credentials: https://${{ secrets.GITHUB_USER }}:${{ secrets.GITHUB_PAT }}@github.com
 ```
 
 ### Use specific Rust version

--- a/action.yml
+++ b/action.yml
@@ -27,12 +27,17 @@ inputs:
     description: "The Rust version that is updated to before running cargo deny"
     required: false
     default: ""
+  credentials:
+    description: "The git credentials for credential.helper store using github username and github's private access token (PAT)"
+    required: false
+    default: ""
 
 runs:
   using: "docker"
   image: "Dockerfile"
   args:
     - ${{ inputs.rust-version }}
+    - ${{ inputs.credentials }}
     - --log-level
     - ${{ inputs.log-level }}
     - ${{ inputs.arguments }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,17 @@ then
     rustup default "$1"
 fi
 
+if [ -n "$2" ]
+then
+    git config --global credential.helper store
+    git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/
+    git config --global --add url.https://github.com/.insteadOf git@github.com:
+
+    echo $2 > $HOME/.git-credentials
+    chmod 600 $HOME/.git-credentials
+fi
+
+shift
 shift
 
 cargo-deny $*


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Added new argument `credentials` to the action which initializes the internal git client. The internal git client will be forced  to use these provided credentials. In this way someone could add required credential for `internal` or `private` git repositories used in cargo crates. 

### Related Issues

https://github.com/EmbarkStudios/cargo-deny-action/issues/53
