### PR TITLE
Bump rust version from 1.60.0 to 1.65.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,4 @@ jobs:
         run: docker run -v ${PWD}/test:/test test-cargo-deny "" "" --manifest-path test/Cargo.toml list
 
       - name: Run check
-        run: docker run -v ${PWD}/test:/test test-cargo-deny 1.60.0 "" --manifest-path test/Cargo.toml --all-features check
+        run: docker run -v ${PWD}/test:/test test-cargo-deny 1.65.0 "" --manifest-path test/Cargo.toml --all-features check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.60.0-alpine3.15
+FROM rust:1.65.0-alpine3.15
 
 ENV deny_version="0.12.1"
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This action will run `cargo-deny check` and report failure if any banned crates 
 
 The action has three optional inputs
 
-* `rust-version`: The rust/cargo version to use, updated before cargo-deny is run. Defaults to the version in the image, which is currently **1.60.0**.
+* `rust-version`: The rust/cargo version to use, updated before cargo-deny is run. Defaults to the version in the image, which is currently **1.65.0**.
 * `log-level`: The log level to use for `cargo-deny`, default is `warn`
 * `command`: The command to use for `cargo-deny`, default is `check`
 * `arguments`: The argument to pass to `cargo-deny`, default is `--all-features`. See [Common Options](https://embarkstudios.github.io/cargo-deny/cli/common.html) for a list of the available options.
@@ -70,7 +70,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: EmbarkStudios/cargo-deny-action@v1
       with:
-        rust-version: "1.60.0"
+        rust-version: "1.65.0"
         log-level: warn
         command: check
         arguments: --all-features


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

rust 1.64 added support for [inherited workspace dependencies](https://doc.rust-lang.org/nightly/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace).

Currently this github action has trouble with the new format:

```
Error: -03 22:23:52 [ERROR] `cargo metadata` exited with an error: error: failed to load manifest for workspace member `/github/workspace/foo`

Caused by:
  failed to load manifest for dependency `foo`

Caused by:
  failed to parse manifest at `/github/workspace/foo/Cargo.toml`

Caused by:
  invalid type: map, expected SemVer version for key `package.version`
```

Bumping the default rust version should fix it.

