### PR TITLE
Bump cargo-deny to 0.13.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.60.0-alpine3.15
 
-ENV deny_version="0.12.1"
+ENV deny_version="0.13.5"
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Updates cargo-deny to 0.13.5, from 0.12.1 currently.

Particularly interesting for us as we need a fix that shipped in 0.12.2.
