### PR TITLE
Fix missed bump to checkout@v3 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: EmbarkStudios/cargo-deny-action@v1
       with:
         command: check ${{ matrix.checks }}


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Looks like a bump to GH `actions/checkout@v3` was missed in the recommended pipeline in the README. This just fixes that so the recommended pipeline matches the rest of the README.
