### PR TITLE
Add capabilities to fetch ssh dependencies by passing an ssh key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM rust:1.71.0-alpine3.18
+FROM rust:1.77.2-alpine3.19
 
-ENV deny_version="0.14.21"
+ENV deny_version="0.14.22"
 
 RUN set -eux; \
     apk update; \
-    apk add bash curl git tar; \
+    apk add bash curl git tar openssh; \
     curl --silent -L https://github.com/EmbarkStudios/cargo-deny/releases/download/$deny_version/cargo-deny-$deny_version-x86_64-unknown-linux-musl.tar.gz | tar -xzv -C /usr/bin --strip-components=1;
 
 # Ensure rustup is up to date.

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,18 @@ inputs:
     description: "The git credentials for credential.helper store using github username and github's private access token (PAT)"
     required: false
     default: ""
+  ssh-key:
+    description: "Set the used ssh key"
+    required: false
+    default: ""
+  ssh-known-hosts:
+    description: "Set ssh known hosts"
+    required: false
+    default: ""
+  use-git-cli:
+    description: "Set CARGO_NET_GIT_FETCH_WITH_CLI"
+    required: false
+    default: "false"
 
 runs:
   using: "docker"
@@ -42,6 +54,9 @@ runs:
   args:
     - ${{ inputs.rust-version }}
     - ${{ inputs.credentials }}
+    - ${{ inputs.ssh-key }}
+    - ${{ inputs.ssh-known-hosts }}
+    - ${{ inputs.use-git-cli }}
     - --log-level
     - ${{ inputs.log-level }}
     - --manifest-path

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,30 @@ then
     chmod 600 "$HOME/.git-credentials"
 fi
 
+if [ -n "$3" ]
+then
+    mkdir -p "/root/.ssh"
+    chmod 0700 "/root/.ssh"
+    echo "${3}" > "/root/.ssh/id_rsa"
+    chmod 0600 "/root/.ssh/id_rsa"
+fi
+
+if [ -n "$4" ]
+then
+    mkdir -p "/root/.ssh"
+    chmod 0700 "/root/.ssh"
+    echo "${4}" > "/root/.ssh/known_hosts"
+    chmod 0600 "/root/.ssh/known_hosts"
+fi
+
+if [ -n "$5" ]
+then
+    export CARGO_NET_GIT_FETCH_WITH_CLI="$5"
+fi
+
+shift
+shift
+shift
 shift
 shift
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Currently there is no way in cargo-deny-action to fetch and evaluate ssh dependencies (see #67).
I order to enable the feature this PR introduces four changes:

1. A new action input to pass a private ssh-key for ssh authentication
2. A new action input to pass ssh known hosts so a ssh connection can be established
3. A new action input to use the git cli instead of the build in cargo fetcher to enable ssh git repositories
4. It adds openssh to the Docker image to allow git to use ssh for cloning

It also updates the rust + cargo_deny version. If you wish to separate these changes, feel free to
change this.

### Related Issues

Fixes #67