### PR TITLE
Update Docker image to Rust 1.85.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.84.1-alpine3.20
+FROM rust:1.85.0-alpine3.20
 
 ENV deny_version="0.17.0"
 


### PR DESCRIPTION
This makes cargo-deny runnable against projects with `edition = "2024"`, as only the latest Rust 1.85 understands the new edition without nightly feature flags.

### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Bumping the Docker image for the action to Rust 1.85.0 as base image.

Currently I'm in the process of updating several projects to Rust Edition 2024 and noticed that the `cargo-deny-action` fails due to not understanding the new edition yet (well it's not cargo-deny itself, but cargo from the base image).

### Related Issues

None.
