### PR TITLE
Install active toolchain by default if rust-version is not passed

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,12 @@ if [ -n "$1" ]
 then
     rustup set profile minimal
     rustup default "$1"
+else
+    # Ensure active toolchain is installed if explicit rust-version is not passed.
+    # Starting with v1.28, rustup is not going to install active toolchain by default,
+    # and this is needed to install the active toolchain if it's not installed.
+    # See https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html#whats-new-in-rustup-1280
+    rustup show active-toolchain || rustup toolchain install
 fi
 
 if [ -n "$2" ]


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Starting with v1.28, rustup is not going to install active toolchain by default and that might break some uses, like: 
- https://github.com/EmbarkStudios/cargo-deny-action/issues/91 
- https://github.com/awslabs/mountpoint-s3/actions/runs/13637654145/job/38120236386?pr=1299#step:4:15

Not sure if this is the best solution, but this PR tries to preserve the previous behaviour of rustup as described in https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html#whats-new-in-rustup-1280

### Related Issues

- https://github.com/EmbarkStudios/cargo-deny-action/issues/91
