### PR TITLE
Workaround rustup 1.28

### DIFF
--- a/.cargo/deny.toml
+++ b/.cargo/deny.toml
@@ -1,2 +1,2 @@
 [licenses]
-allow = ["Unicode-DFS-2016", "MIT", "Apache-2.0"]
+allow = ["Unicode-3.0", "MIT", "Apache-2.0"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,12 +38,16 @@ jobs:
             check \
             ""
 
-  # Ensures the action in the PR still works
-  # test:
-  #   runs-on: ubuntu-22.04
-  #   if: github.event_name == 'pull_request'
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: EmbarkStudios/cargo-deny-action@prep-release # change branch name to PR branch if you are changing it
-  #       # with:
-  #       #   manifest-path: test/Cargo.toml
+      - name: Run check w/rust-toolchain.toml
+        run: |
+          mv ./test/rt.toml ./test/rust-toolchain.toml
+          docker run -v $PWD/test:/test test-cargo-deny \
+            "" \
+            "" \
+            "" \
+            "" \
+            "false" \
+            --log-level warn \
+            --manifest-path test/Cargo.toml \
+            check \
+            ""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,8 @@ jobs:
 
       - name: Run check w/rust-toolchain.toml
         run: |
-          mv ./test/rt.toml ./test/rust-toolchain.toml
-          docker run -v $PWD/test:/test test-cargo-deny \
+          mv ./test/rt.toml ./rust-toolchain.toml
+          docker run -v $PWD:/ test-cargo-deny \
             "" \
             "" \
             "" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run check w/rust-toolchain.toml
         run: |
           mv ./test/rt.toml ./rust-toolchain.toml
-          docker run -v $PWD:/ test-cargo-deny \
+          docker run -v $PWD:/test test-cargo-deny \
             "" \
             "" \
             "" \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "root"
 version = "0.1.0"
+edition = "2024"
 
 [dependencies]
 openssl = "0.10"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,13 +7,9 @@ if [ -n "$1" ]
 then
     rustup set profile minimal
     rustup default "$1"
-else
-    # Ensure active toolchain is installed if explicit rust-version is not passed.
-    # Starting with v1.28, rustup is not going to install active toolchain by default,
-    # and this is needed to install the active toolchain if it's not installed.
-    # See https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html#whats-new-in-rustup-1280
-    rustup show active-toolchain || rustup toolchain install
 fi
+
+rustup toolchain install
 
 if [ -n "$2" ]
 then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -l
+#!/bin/bash
 set -e
 
 PATH=$PATH:/usr/local/cargo/bin
@@ -7,8 +7,6 @@ if [ -n "$1" ]; then
     rustup set profile minimal
     rustup default "$1"
 fi
-
-rustup toolchain install
 
 if [ -n "$2" ]; then
     git config --global credential.helper store
@@ -42,5 +40,8 @@ shift 5
 # Due to how github actions run containers we need to explicitly force colors
 # as TTY detection fails inside them
 export CARGO_TERM_COLOR="always"
+
+# Workaround for rustup 1.28 completely breaking rust-toolchain.toml
+(cd "$(dirname "$4")"; rustup show || rustup toolchain install)
 
 cargo-deny $*

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,16 +3,14 @@ set -e
 
 PATH=$PATH:/usr/local/cargo/bin
 
-if [ -n "$1" ]
-then
+if [ -n "$1" ]; then
     rustup set profile minimal
     rustup default "$1"
 fi
 
 rustup toolchain install
 
-if [ -n "$2" ]
-then
+if [ -n "$2" ]; then
     git config --global credential.helper store
     git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/
     git config --global --add url.https://github.com/.insteadOf git@github.com:
@@ -21,32 +19,25 @@ then
     chmod 600 "$HOME/.git-credentials"
 fi
 
-if [ -n "$3" ]
-then
+if [ -n "$3" ]; then
     mkdir -p "/root/.ssh"
     chmod 0700 "/root/.ssh"
     echo "${3}" > "/root/.ssh/id_rsa"
     chmod 0600 "/root/.ssh/id_rsa"
 fi
 
-if [ -n "$4" ]
-then
+if [ -n "$4" ]; then
     mkdir -p "/root/.ssh"
     chmod 0700 "/root/.ssh"
     echo "${4}" > "/root/.ssh/known_hosts"
     chmod 0600 "/root/.ssh/known_hosts"
 fi
 
-if [ -n "$5" ]
-then
+if [ -n "$5" ]; then
     export CARGO_NET_GIT_FETCH_WITH_CLI="$5"
 fi
 
-shift
-shift
-shift
-shift
-shift
+shift 5
 
 # Due to how github actions run containers we need to explicitly force colors
 # as TTY detection fails inside them

--- a/test/rt.toml
+++ b/test/rt.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2025-01-03"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
rustup 1.28 completely breaks this action if the user has a rust-toolchain.toml as it will no longer install it as needed, we need to instead cd into the parent directory of the manifest and check if rustup show fails with a missing toolchain.

This probably now breaks other scenarios that were previously automatically handled but those can be fixed if someone raises an issue.

Resolves: #94 