### PR TITLE
add management of arch runner in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ENV deny_version="0.19.8"
 RUN set -eux; \
     apk update; \
     apk add bash curl git tar openssh; \
-    curl --silent -L https://github.com/EmbarkStudios/cargo-deny/releases/download/$deny_version/cargo-deny-$deny_version-x86_64-unknown-linux-musl.tar.gz | tar -xzv -C /usr/bin --strip-components=1;
+    ARCH=$(uname -m); \
+    curl --silent -L https://github.com/EmbarkStudios/cargo-deny/releases/download/$deny_version/cargo-deny-$deny_version-$ARCH-unknown-linux-musl.tar.gz | tar -xzv -C /usr/bin --strip-components=1;
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
This allow the action to run on aarch64/arm64 runner.

### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

In the `RUN` step of Dockerfile, I added the retrieval of the architecture using the command `$(uname -m)` and use it in download url construct. 

### Related Issues

#102 
