### PR TITLE
Add output file support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
             "" \
             "" \
             "false" \
+            "" \
             --log-level warn \
             --manifest-path test/Cargo.toml \
             "" \
@@ -32,6 +33,7 @@ jobs:
             "" \
             "" \
             "false" \
+            "" \
             --log-level warn \
             --manifest-path test/Cargo.toml \
             --all-features \
@@ -47,7 +49,45 @@ jobs:
             "" \
             "" \
             "false" \
+            "" \
             --log-level warn \
             --manifest-path test/Cargo.toml \
             check \
             ""
+
+      - name: Run list with output file
+        run: |
+          output_dir="$(mktemp -d)"
+          docker run -v $PWD/test:/test -v "$output_dir:/output" \
+            -e GITHUB_OUTPUT=/output/github-output \
+            test-cargo-deny \
+            "" \
+            "" \
+            "" \
+            "" \
+            "false" \
+            "/output/licenses.txt" \
+            --log-level warn \
+            --manifest-path test/Cargo.toml \
+            "" \
+            list \
+            ""
+          test -s "$output_dir/licenses.txt"
+          grep '^output-file=/output/licenses.txt$' "$output_dir/github-output"
+
+      - name: Run check with SARIF output file
+        run: |
+          output_dir="$(mktemp -d)"
+          docker run -v $PWD/test:/test -v "$output_dir:/output" test-cargo-deny \
+            "" \
+            "" \
+            "" \
+            "" \
+            "false" \
+            "/output/cargo-deny.sarif" \
+            --log-level warn \
+            --manifest-path test/Cargo.toml \
+            "--format sarif --all-features" \
+            check \
+            ""
+          grep '"version": "2.1.0"' "$output_dir/cargo-deny.sarif"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny) for instructions
 
 This action will run `cargo-deny check` and report failure if any banned crates or disallowed open source licenses are found used in the crate or its dependencies.
 
-The action has three optional inputs
+The action has the following optional inputs
 
 * `rust-version`: The rust/cargo version to use, updated before cargo-deny is run. Defaults to the version in the image, which is currently **1.71.0**.
 * `log-level`: The log level to use for `cargo-deny`, default is `warn`
@@ -26,6 +26,7 @@ The action has three optional inputs
 * `manifest-path`: The path to a Cargo.toml file to use as the root. Defaults to `./Cargo.toml`. Note this argument is always passed, so you can't have it in `arguments` as well, just set it it to the value you had in `arguments` if you were using it there.
 * `command-arguments` The argument to pass to the command, default is emtpy. See options for [each command](https://embarkstudios.github.io/cargo-deny/cli/index.html).
 * `credentials` This argument stores the credentials in the file `$HOME/git-credentials`, and configures git to use it. The credential must match the format `https://user:pass@github.com`
+* `output-file` Write `cargo-deny` stdout to the specified file and expose the path as an action output.
 
 ### Example pipeline
 
@@ -76,6 +77,32 @@ jobs:
         log-level: warn
         command: check
         arguments: --all-features
+```
+
+### Write machine-readable output to a file
+
+`cargo-deny` can write machine-readable formats such as JSON or SARIF to stdout. Set `output-file` to save stdout for another workflow step.
+
+```yaml
+name: CI
+on: [push, pull_request]
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+    - uses: actions/checkout@v4
+    - uses: EmbarkStudios/cargo-deny-action@v2
+      id: cargo-deny
+      with:
+        arguments: --format sarif --all-features
+        output-file: cargo-deny.sarif
+    - uses: github/codeql-action/upload-sarif@v4
+      if: always()
+      with:
+        sarif_file: ${{ steps.cargo-deny.outputs.output-file }}
 ```
 
 ### Recommended pipeline if not using advisories, to only run on dependency changes

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ branding:
   icon: "slash"
   color: "red"
 
+outputs:
+  output-file:
+    description: "Path written by output-file, if set"
+
 inputs:
   command:
     description: "The command to run with cargo-deny"
@@ -47,6 +51,10 @@ inputs:
     description: "Set CARGO_NET_GIT_FETCH_WITH_CLI"
     required: false
     default: "false"
+  output-file:
+    description: "Path to write cargo-deny stdout to"
+    required: false
+    default: ""
 
 runs:
   using: "docker"
@@ -57,6 +65,7 @@ runs:
     - ${{ inputs.ssh-key }}
     - ${{ inputs.ssh-known-hosts }}
     - ${{ inputs.use-git-cli }}
+    - ${{ inputs.output-file }}
     - --log-level
     - ${{ inputs.log-level }}
     - --manifest-path

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,7 +35,9 @@ if [ -n "$5" ]; then
     export CARGO_NET_GIT_FETCH_WITH_CLI="$5"
 fi
 
-shift 5
+output_file="$6"
+
+shift 6
 
 # Due to how github actions run containers we need to explicitly force colors
 # as TTY detection fails inside them
@@ -43,5 +45,20 @@ export CARGO_TERM_COLOR="always"
 
 # Workaround for rustup 1.28 completely breaking rust-toolchain.toml
 (cd "$(dirname "$4")"; rustup show || rustup toolchain install)
+
+if [ -n "$output_file" ]; then
+    mkdir -p "$(dirname "$output_file")"
+
+    set +e
+    cargo-deny $* > "$output_file"
+    status=$?
+    set -e
+
+    if [ -n "$GITHUB_OUTPUT" ]; then
+        echo "output-file=$output_file" >> "$GITHUB_OUTPUT"
+    fi
+
+    exit "$status"
+fi
 
 cargo-deny $*


### PR DESCRIPTION
## Summary

This adds a generic `output-file` input for writing `cargo-deny` stdout to a file, and exposes that path as an action output.

This is intentionally narrower than the SARIF/GitHub Code Scanning idea from #110. It does not add upload behavior or any GitHub-specific SARIF handling; it only makes existing machine-readable stdout output easier to compose in workflows.

If this still feels like too much surface area for this action, I’m fine with closing it. I wanted to put up the smallest concrete version so the tradeoff is easier to evaluate.

## Validation

I manually ran:

- `docker build -t test-cargo-deny .`
- existing `list` and `check` Docker invocations with the new empty positional argument
- the rust-toolchain.toml Docker scenario from a temp repo copy
- `output-file` generation with `GITHUB_OUTPUT` set, including an assertion for `output-file=/output/licenses.txt`
- SARIF output capture, checking that the file contains `"version": "2.1.0"`
- a fork workflow against `joshka/cargo-deny-action@joshka/output-file` covering SARIF upload and a cargo-deny failure that still writes `output-file`: https://github.com/joshka/cargo-deny-action/actions/runs/27341236898
- a fork PR workflow showing the SARIF upload is associated with `refs/pull/1/merge`: https://github.com/joshka/cargo-deny-action/pull/1
- a fork PR workflow with a newly introduced cargo-deny alert on a changed line: https://github.com/joshka/cargo-deny-action/pull/2
- `git diff --check`

AI generated the first pass of this change, and I manually reviewed and validated the behavior above.
