### PR TITLE
fix: correct positional arg shift after use-git-cli deprecation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,11 +31,7 @@ if [ -n "$4" ]; then
     chmod 0600 "/root/.ssh/known_hosts"
 fi
 
-if [ -n "$5" ]; then
-    export CARGO_NET_GIT_FETCH_WITH_CLI="$5"
-fi
-
-shift 5
+shift 4
 
 # Due to how github actions run containers we need to explicitly force colors
 # as TTY detection fails inside them


### PR DESCRIPTION
## Fix positional-argument shift introduced by deprecating `use-git-cli`

`entrypoint.sh` consumes a fixed number of leading positional arguments and then runs `cargo-deny "$@"` on the remainder:

```sh
# $1 rust-version, $2 credentials, $3 ssh-key, $4 ssh-known-hosts, $5 use-git-cli
if [ -n "$5" ]; then
    export CARGO_NET_GIT_FETCH_WITH_CLI="$5"
fi
shift 5
```

Commit `8b229e2` ("Deprecate use-git-cli") removed the `use-git-cli` entry from `action.yml`'s `args:` but left `entrypoint.sh` reading five leading positionals. As a result `--log-level` is consumed into the (now nonexistent) `use-git-cli` slot, `shift 5` discards it, and the log-level value falls into `cargo-deny`'s subcommand position — so every run fails with:

```
error: unrecognized subcommand 'warn'
```

This regressed `@v2` at the v2.1.0 release.

## Change

Drop the `use-git-cli` positional handling (consistent with its deprecation to no-effect) and shift one fewer:

```diff
-if [ -n "$5" ]; then
-    export CARGO_NET_GIT_FETCH_WITH_CLI="$5"
-fi
-
-shift 5
+shift 4
```

## Verification

Simulating the entrypoint's `shift N` then `cargo-deny $*` against the exact arg vector GitHub passes:

| args + entrypoint | resulting command | result |
|---|---|---|
| v2.0.20 (`use-git-cli` present) + `shift 5` | `cargo-deny --log-level warn --manifest-path ./Cargo.toml check licenses bans sources` | ok (baseline) |
| v2.1.0 (`use-git-cli` removed) + `shift 5` | `cargo-deny warn --manifest-path ./Cargo.toml check licenses bans sources` | `unrecognized subcommand 'warn'` |
| v2.1.0 + `shift 4` (this PR) | `cargo-deny --log-level warn --manifest-path ./Cargo.toml check licenses bans sources` | ok — identical to baseline |

The `shift 4` result is byte-identical to the working v2.0.20 layout, and the downstream `dirname "$4"` (manifest directory) reference still resolves to the manifest path as before.

Fixes #114
