### PR TITLE
fix use-git-cli deprecation shifting args by the wrong offset

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
             "" \
             "" \
             "" \
-            "false" \
             --log-level warn \
             --manifest-path test/Cargo.toml \
             "" \
@@ -31,7 +30,6 @@ jobs:
             "" \
             "" \
             "" \
-            "false" \
             --log-level warn \
             --manifest-path test/Cargo.toml \
             --all-features \
@@ -46,7 +44,6 @@ jobs:
             "" \
             "" \
             "" \
-            "false" \
             --log-level warn \
             --manifest-path test/Cargo.toml \
             check \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,11 +31,7 @@ if [ -n "$4" ]; then
     chmod 0600 "/root/.ssh/known_hosts"
 fi
 
-if [ -n "$5" ]; then
-    export CARGO_NET_GIT_FETCH_WITH_CLI="$5"
-fi
-
-shift 5
+shift 4
 
 # Due to how github actions run containers we need to explicitly force colors
 # as TTY detection fails inside them


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

https://github.com/EmbarkStudios/cargo-deny-action/commit/8b229e2cbac05ffa3e4e6646023a0b4ee717c736 broke cargo-deny-action due to removing an arg in the action yml, but not adjusting the entrypoint.sh to handle it.

Compared to https://github.com/EmbarkStudios/cargo-deny-action/pull/115, this PR also adjusts your docker-based testing framework so [CI passes](https://github.com/Firestar99/cargo-deny-action/actions/runs/29241212865/job/86787449366).

### Related Issues

close https://github.com/EmbarkStudios/cargo-deny-action/issues/113